### PR TITLE
Bugfix/issue 2/multiple directories in repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM marcellodesales/github-enterprise-prereceive-hook-base
 MAINTAINER Marcello_deSales@intuit.com
 
-RUN \
-  apk add --no-cache py-pip && \
-  pip install yamllint pyyaml pyjavaproperties
+RUN apk add --no-cache py-pip
 
-ADD ./validate_config_files.py /home/git/test.git/hooks/pre-receive
+COPY requirements.txt requirements.txt
+
+RUN pip2 install -r requirements.txt
+
+COPY ./validate_config_files.py /home/git/test.git/hooks/pre-receive

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+
+  intuit-spring-cloud-config-validator:
+    image: intuit/intuit-spring-cloud-config-validator:1.1.1
+    build: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 yamllint
 pyjavaproperties
+glob2

--- a/validate_config_files.py
+++ b/validate_config_files.py
@@ -251,7 +251,8 @@ class Validator:
     """Lists all the configuration files in a given directory"""
 
     # Valid configuration files
-    configMatches = ["*.json", "*.yaml", "*.yml", "*.properties", ".*matrix*.json"]
+    configMatches = ["**/*.json", "**/*.yaml", "**/*.yml", "**/*.properties"]
+    print "Filtering Spring Cloud Config Server's compatible files: ", configMatches
 
     # Get all the types config files based on the matches.
     allConfigs = []

--- a/validate_config_files.py
+++ b/validate_config_files.py
@@ -3,7 +3,7 @@
 import sys
 import subprocess
 import os
-import glob
+import glob2
 import json
 import yaml
 
@@ -184,7 +184,7 @@ class Validator:
   def listConfigFiles(dirPath, extension):
     """Lists all the config files in a given directory with the given extension"""
 
-    return glob.glob(os.path.join(dirPath, extension))
+    return glob2.glob(os.path.join(dirPath, extension))
 
   # Saves the given content in the file path from the contextDir
   @staticmethod

--- a/validate_config_files.py
+++ b/validate_config_files.py
@@ -252,7 +252,7 @@ class Validator:
 
     # Valid configuration files
     configMatches = ["**/*.json", "**/*.yaml", "**/*.yml", "**/*.properties"]
-    print "Filtering Spring Cloud Config Server's compatible files: ", configMatches
+    print "Filtering Spring Cloud Config Server's files: ", configMatches
 
     # Get all the types config files based on the matches.
     allConfigs = []


### PR DESCRIPTION
# Multiple directories validation

* Fix the validation for files under directories
* Identified that the lib `glob` does NOT look recursive
  * Replacing it with `glob2`: https://github.com/miracle2k/python-glob2/#recursive-glob

# Solution Logs

* Created a repo with files and a directory called `idps/idps.yaml`
* Pushed and got the proper validation

```console
GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 52311 -i /Users/mdesales/dev/github/public/intuit/intuit-spring-cloud-config-validator/id_rsa_from_github_simulator_server" git push test develop -f
Warning: Permanently added '[172.28.110.65]:52311' (ECDSA) to the list of known hosts.
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 8 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 358 bytes | 358.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: ##################################################
remote: ###### Spring Cloud Config Validator 1.1.1 #######
remote: ##################################################
remote: Validating new branch...
remote: Processing commit=a67275c202a8d2d070e3cf19fe135815a4ad110b ref=refs/heads/develop
remote: => Validating SHA a67275c202a8d2d070e3cf19fe135815a4ad110b
remote: Filtering Spring Cloud Config Server's files:  ['**/*.json', '**/*.yaml', '**/*.yml', '**/*.properties']
remote: (v) File config_msaas_test_01-prd.yml is valid!
remote: (v) File config_msaas_test_01-qal.yml is valid!
remote: (v) File config_msaas_test_01.yml is valid!
remote: (v) File config_msaas_test_01-prf.yml is valid!
remote: (x) File idps/idps.yaml is invalid: [2:33: syntax error: mapping values are not allowed here]
remote: (v) File application.yml is valid!
remote: (v) File config_msaas_test_01-e2e.yml is valid!
remote: (x) File config_msaas_test_01-dev.yml is invalid: [13:4: syntax error: mapping values are not allowed here]
```